### PR TITLE
webview build: Update target browser versions, and clarify.

### DIFF
--- a/src/webview/js/js.js
+++ b/src/webview/js/js.js
@@ -17,6 +17,8 @@ import rewriteHtml from './rewriteHtml';
 /*
  * Supported platforms:
  *
+ * * (When updating these, be sure to update tools/generate-webview-js too.)
+ *
  * * We support iOS 11.  So this code needs to work on Mobile Safari 11.
  *   Graceful degradation is acceptable below iOS 13 / Mobile Safari 13.
  *

--- a/tools/generate-webview-js
+++ b/tools/generate-webview-js
@@ -12,6 +12,40 @@ const util = require('util');
 const sourceFilename = 'src/webview/js/js.js';
 const outputFilename = 'src/webview/js/generatedEs3.js';
 
+/**
+ * The minimum browser versions we support for the WebView.
+ *
+ * These should agree with the block comment at the top of js.js.
+ * See also docs/architecture/platform-versions.md.
+ */
+/*
+  Fun tip for seeing which transforms will stop being needed on an upgrade:
+    $ jq -c '
+         to_entries | map(.value + { name: .key })
+         | sort_by(.chrome | tonumber)  # or (.ios // "999" | tonumber)
+         | .[] | { chrome, safari, ios, name }
+       ' node_modules/@babel/compat-data/data/plugins.json
+*/
+const targetPlatforms = {
+  // Babel doesn't distinguish Chrome for Android vs. other Chrome.
+  // See their data table, in node_modules/@babel/compat-data/data/plugins.json .
+  //
+  // Keep this at the Chrome version originally shipped with the oldest
+  // Android version we support.
+  chrome: 37,
+
+  // (Babel accepts an "android" key here too.  But that refers to the old
+  // Android System WebView, which Android 5 replaced with an auto-updating
+  // Chrome; see our b3eced058.  So there's no such thing as "android: 5" or
+  // later, and because we don't support older Android versions than that,
+  // we don't use the "android" key.)
+
+  // Babel does distinguish `safari` (meaning on macOS, I guess) from `ios`.
+  // Some features arrive in e.g. "safari 11.1" but "ios 11.3", or in
+  // 13.1 vs 13.4, so the distinction is still relevant.
+  ios: 11,
+};
+
 // Disable the default react-native transformations.
 // See `$ROOT/babel.config.js`.
 process.env.BABEL_ENV = 'webview';
@@ -72,13 +106,9 @@ ${es3Code.replace(/\\/g, '\\\\')}
           ['@babel/plugin-proposal-optional-chaining'],
         ],
 
-        /* See comments in src/webview/js/js.js for details about the target set
-           selected here.
-
-           See comments below about (the absence of) automatic polyfills via
-           `core-js`.
-        */
-        presets: [['@babel/preset-env', { targets: { android: '4.4', chrome: 30, safari: 10 } }]],
+        // See comments below about (the absence of) automatic polyfills via
+        // `core-js`.
+        presets: [['@babel/preset-env', { targets: targetPlatforms }]],
       }),
     ],
   });


### PR DESCRIPTION
These were kind of tucked away in the middle of a bunch of logic.
Perhaps more importantly, they had a comment pointing to js.js but
nothing vice versa -- so they weren't discoverable when updating
our canonical list of supported platforms.

And in fact, we didn't remember this line and update it when we most
recently updated that list, in c953bc336 a few weeks ago... nor the
time before that, in b3eced058 a year ago... and the latter commit
came just a few weeks after we wrote this code in the first place.

So, apply those two updates; and pull these minimums out with more
explanation, and linked both to and from the canonical list in js.js.

This update doesn't cause any change to the generated output; in fact
it turns out that there are no Babel plugins at all that are affected
by upgrading Chrome between versions 13 and 38.  That's perhaps
unsurprising when you remember that Chrome 37 is what shipped with
Android 5, in 2014, as the JS language was still just emerging from
its long period of stagnation.